### PR TITLE
feat(index/RightBar): 新增几个常用信息链接

### DIFF
--- a/src/pages/index/components/RightBar.vue
+++ b/src/pages/index/components/RightBar.vue
@@ -30,6 +30,18 @@ const commonLinkList = reactive([
     title: '报告系统使用问题'
   },
   {
+    url: '/paste',
+    title: '使用公共剪贴板'
+  },
+  {
+    url: '/events',
+    title: '查阅近期活动信息'
+  },
+  {
+    url: '/internship',
+    title: '查阅近期实习机会及待办项目'
+  },
+  {
     url: 'https://github.com/AOSC-Dev/aosc-os-abbs/issues/new?assignees=&labels=security&projects=&template=security-vulnerabilities-report.yml',
     title: '报告安全漏洞'
   },


### PR DESCRIPTION
其中公共剪贴板是用户经常报告难以找到的功能，其他两个页面根据同理估测并添加

新增链接如图：

![图片](https://github.com/user-attachments/assets/afe20bc8-bdff-4b5f-9607-8b9e96e36a40)
