### PR TITLE
feat: 在点击悬浮提示时将其隐藏; chore: 修改“下载-校验和使用”部分的措辞

### DIFF
--- a/src/pages/download/components/DownloadButton.vue
+++ b/src/pages/download/components/DownloadButton.vue
@@ -65,14 +65,6 @@ const onClick = () => {
 };
 </script>
 
-<script>
-export default {
-  data() {
-    return { isVisible: false }
-  }
-}
-</script>
-
 <template>
   <div>
     <el-popover
@@ -80,11 +72,10 @@ export default {
       :placement="popoverData?.placement"
       :hide-after="0"
       trigger="hover"
-      :content="popoverData?.content"
-      ref="whatsThisArchPopup"
-      manual
-      v-model="isVisible">
-      <div @click="$refs.whatsThisArchPopup.hide()">{{ popoverData?.content }}</div>
+      ref="whatsThisArchPopup">
+      <div @click="$refs.whatsThisArchPopup.hide()">{{
+        popoverData?.content
+      }}</div>
       <template #reference>
         <button
           :disabled="disabled"

--- a/src/pages/download/components/DownloadButton.vue
+++ b/src/pages/download/components/DownloadButton.vue
@@ -65,6 +65,14 @@ const onClick = () => {
 };
 </script>
 
+<script>
+export default {
+  data() {
+    return { isVisible: false }
+  }
+}
+</script>
+
 <template>
   <div>
     <el-popover
@@ -72,7 +80,11 @@ const onClick = () => {
       :placement="popoverData?.placement"
       :hide-after="0"
       trigger="hover"
-      :content="popoverData?.content">
+      :content="popoverData?.content"
+      ref="whatsThisArchPopup"
+      manual
+      v-model="isVisible">
+      <div @click="$refs.whatsThisArchPopup.hide()">{{ popoverData?.content }}</div>
       <template #reference>
         <button
           :disabled="disabled"

--- a/src/pages/download/components/DownloadButtonGroup.vue
+++ b/src/pages/download/components/DownloadButtonGroup.vue
@@ -12,25 +12,14 @@ const props = defineProps({
 const expand = ref(false);
 </script>
 
-<script>
-export default {
-  data() {
-    return { isVisible: false }
-  }
-}
-</script>
-
 <template>
   <div class="flex flex-col gap-1">
     <div class="leading-none">
       <span v-if="title" class="text-[10pt] font-[450]">{{ title }}</span>
-      <el-popover 
-        placement="top"
-        width="233"
-        ref="whatsThisArchLevelPopup"
-        manual
-        v-model="isVisible">
-        <div @click="$refs.whatsThisArchLevelPopup.hide()">{{ description }}</div>
+      <el-popover placement="top" width="233" ref="whatsThisArchLevelPopup">
+        <div @click="$refs.whatsThisArchLevelPopup.hide()"
+          >{{ description }}
+        </div>
         <template #reference>
           <span class="text-[8pt] font-[450]">（这是什么？）</span>
         </template>

--- a/src/pages/download/components/DownloadButtonGroup.vue
+++ b/src/pages/download/components/DownloadButtonGroup.vue
@@ -12,11 +12,25 @@ const props = defineProps({
 const expand = ref(false);
 </script>
 
+<script>
+export default {
+  data() {
+    return { isVisible: false }
+  }
+}
+</script>
+
 <template>
   <div class="flex flex-col gap-1">
     <div class="leading-none">
       <span v-if="title" class="text-[10pt] font-[450]">{{ title }}</span>
-      <el-popover placement="top" width="233" :content="description">
+      <el-popover 
+        placement="top"
+        width="233"
+        ref="whatsThisArchLevelPopup"
+        manual
+        v-model="isVisible">
+        <div @click="$refs.whatsThisArchLevelPopup.hide()">{{ description }}</div>
         <template #reference>
           <span class="text-[8pt] font-[450]">（这是什么？）</span>
         </template>

--- a/src/pages/download/components/DownloadDetailsMain.vue
+++ b/src/pages/download/components/DownloadDetailsMain.vue
@@ -74,7 +74,7 @@ onMounted(() => {
     <p>我们推荐您在下载后校验相关文件的 SHA-256 校验和，详情如下：</p>
     <CopyCodeComponent :content="sha256sum" button-text="复制 SHA-256 校验和" />
 
-    <p>要制作{{ fileType }}，我们建议您使用启动盘制作向导。</p>
+    <p>如果您在使用 Windows 或 macOS，我们建议您从这里下载“AOSC 启动盘制作向导”用来制作{{ fileType }}：</p>
     <el-container class="flex-wrap">
       <AppLink
         v-for="info in mediaWritersInfo"
@@ -85,17 +85,11 @@ onMounted(() => {
         {{ info.name }}
       </AppLink>
     </el-container>
-    <p>
-      如果您在使用安同 OS，可从应用菜单直接启动“启动盘制作向导”工具制作{{
-        fileType
-      }}；如果您在使用其他 Linux 系统，建议使用
-      <AppLink to="https://etcher.balena.io/" target="_blank"
-        >balenaEtcher</AppLink
-      >
+    <p>如果您在使用安同 OS，可从应用菜单直接启动“启动盘制作向导”工具制作{{ fileType }}。</p>
+    <p>如果您在使用其他 Linux 系统，建议使用
+      <AppLink to="https://etcher.balena.io/" target="_blank">balenaEtcher</AppLink>
       或
-      <AppLink to="https://gitlab.com/bztsrc/usbimager" target="_blank"
-        >usbimager</AppLink
-      >
+      <AppLink to="https://gitlab.com/bztsrc/usbimager" target="_blank">usbimager</AppLink>
       工具制作{{ fileType }}。
     </p>
 


### PR DESCRIPTION
1. 为避免下载页面的悬浮提示(el-popover)遮盖按钮，添加功能使提示被点击时隐藏。

2. “下载-校验和使用”部分当中，“创建启动盘”部分的表述，经过修改以后更清晰。