### PR TITLE
fix: some elements of code blocks appear upon footer

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -325,9 +325,9 @@ td {
 .vuepress-markdown-body
   div[class*='v-md-pre-wrapper-']
   pre[class*='v-md-prism-'] {
-  z-index: 0;
+  z-index: unset !important;
 }
 
 .vuepress-markdown-body div[class*='v-md-pre-wrapper-']::before {
-  z-index: 0;
+  z-index: unset !important;
 }


### PR DESCRIPTION
<img width="1338" height="84" alt="" src="https://github.com/user-attachments/assets/1769667a-3818-4c41-a769-4239fc4355bb" />
