### PR TITLE
fix: incorrect contact link reference in download instruction

### DIFF
--- a/components/download/DownloadDetailsAppleSiliconInstruction.vue
+++ b/components/download/DownloadDetailsAppleSiliconInstruction.vue
@@ -24,7 +24,7 @@ const linkValue = tm('allUniversalLink');
 
     <p>
       {{ t('DownloadDetailsAppleSiliconInstruction.text4') }}
-      <link-standard :link="useTIndex(linkValue.contact, 2)" />
+      <link-standard :link="useTIndex(linkValue.local.contact, 2)" />
       {{ t('DownloadDetailsAppleSiliconInstruction.text5') }}
     </p>
   </div>


### PR DESCRIPTION
The `linkValue` in
```
<link-standard :link="useTIndex(linkValue.contact, 2)" />
````
doesn't have member `contact`. In fact, it should be `linkValue.local.contact`.